### PR TITLE
Update EntityManager to use a read-only wrapper over entity groups

### DIFF
--- a/src/__tests__/Entity.test.ts
+++ b/src/__tests__/Entity.test.ts
@@ -43,7 +43,7 @@ describe("Entity", () => {
 
     entity.addTag("testtag");
     expect(entity.hasTag("testtag")).toEqual(true);
-    expect(entityManager.queryTag("testtag").get(entity.id)).toEqual(entity);
+    expect(entityManager.queryTag("testtag")?.get(entity.id)).toEqual(entity);
 
     entity.removeTag("testtag");
     expect(entity.hasTag("testtag")).toEqual(false);


### PR DESCRIPTION
Makes it a lot nicer to work with the EntityManager for queries now

```ts
const group: EntityGroup = entityManager.queryComponents(Position)
for (const [id, entity] of group) {
  // dostuffs
}
```
becomes:
```ts
const group: EntityGroup = entityManager.queryComponents(Position)
for (const entity of group) {
  // dostuffs
}
```

Also, because the query doesn't directly pass back the map anymore, this group is basically a read-only copy. The only remaining gotcha now is that if users store this group, they could be surprised that it changes over time as entities are modified since the `.get()` method is really accessing a group reference underneath

To combat that issue, users can create their own copies of the contents of the query/group:
```ts
const myCopy = Array.from(entityManager.queryComponents(Position))
```
(since `Array.from()` will work on anything that implements `Iterable`)